### PR TITLE
Build the stats dashboard

### DIFF
--- a/src/app/components/profile/profile.component.html
+++ b/src/app/components/profile/profile.component.html
@@ -15,5 +15,8 @@
       <label>Email:</label>
       <span>{{ user.email }}</span>
     </div>
+    
+    <!-- Stats Dashboard -->
+    <app-stats-dashboard></app-stats-dashboard>
   </div>
 </div> 

--- a/src/app/components/profile/profile.component.ts
+++ b/src/app/components/profile/profile.component.ts
@@ -2,11 +2,12 @@ import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { AuthService } from '../../services/auth.service';
 import { User } from '../../types/graphql.types';
+import { StatsDashboardComponent } from '../stats-dashboard/stats-dashboard.component';
 
 @Component({
   selector: 'app-profile',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, StatsDashboardComponent],
   templateUrl: './profile.component.html',
   styleUrls: ['./profile.component.scss']
 })

--- a/src/app/components/stats-dashboard/stats-dashboard.component.html
+++ b/src/app/components/stats-dashboard/stats-dashboard.component.html
@@ -1,0 +1,28 @@
+<p-card class="stats-card">
+    <ng-template pTemplate="header">
+        <div class="card-header">
+            <h2>Workout Stats</h2>
+        </div>
+    </ng-template>
+    
+    <div *ngIf="stats" class="stats-content">
+        <div class="stat-item">
+            <span class="stat-label">Total Workouts</span>
+            <span class="stat-value">{{ stats.totalWorkouts }}</span>
+        </div>
+        <div class="stat-item">
+            <span class="stat-label">Total Calories Burned</span>
+            <span class="stat-value">{{ stats.totalCaloriesBurned }}</span>
+        </div>
+    </div>
+    
+    <div *ngIf="loading" class="loading-state">
+        <p-progressSpinner [style]="{width: '40px', height: '40px'}"></p-progressSpinner>
+        <span>Loading stats...</span>
+    </div>
+    
+    <div *ngIf="error" class="error-state">
+        <i class="pi pi-exclamation-triangle"></i>
+        <span>Error loading stats</span>
+    </div>
+</p-card> 

--- a/src/app/components/stats-dashboard/stats-dashboard.component.scss
+++ b/src/app/components/stats-dashboard/stats-dashboard.component.scss
@@ -1,0 +1,64 @@
+.stats-card {
+  margin: 1rem;
+  
+  .card-header {
+    h2 {
+      margin: 0;
+      font-size: 1.5rem;
+      font-weight: 600;
+    }
+  }
+}
+
+.stats-content {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin: 1rem 0;
+}
+
+.stat-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem;
+  background-color: var(--surface-ground);
+  border-radius: var(--border-radius);
+  
+  .stat-label {
+    font-weight: 500;
+    color: var(--text-color-secondary);
+  }
+  
+  .stat-value {
+    font-size: 1.2rem;
+    font-weight: bold;
+    color: var(--primary-color);
+  }
+}
+
+.loading-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  padding: 2rem;
+  
+  span {
+    color: var(--text-color-secondary);
+  }
+}
+
+.error-state {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 1rem;
+  color: var(--red-500);
+  background-color: var(--red-50);
+  border-radius: var(--border-radius);
+  
+  i {
+    font-size: 1.2rem;
+  }
+} 

--- a/src/app/components/stats-dashboard/stats-dashboard.component.ts
+++ b/src/app/components/stats-dashboard/stats-dashboard.component.ts
@@ -1,0 +1,43 @@
+import { Component, OnInit } from '@angular/core';
+import { Apollo, gql } from 'apollo-angular';
+import { CommonModule } from '@angular/common';
+import { CardModule } from 'primeng/card';
+import { ProgressSpinnerModule } from 'primeng/progressspinner';
+
+const GET_STATS = gql`
+  query GetUserStats($userId: ID!) {
+    getUserStats(userId: $userId) {
+      totalWorkouts
+      totalCaloriesBurned
+    }
+  }
+`;
+
+@Component({
+  selector: 'app-stats-dashboard',
+  templateUrl: './stats-dashboard.component.html',
+  styleUrls: ['./stats-dashboard.component.scss'],
+  standalone: true,
+  imports: [CommonModule, CardModule, ProgressSpinnerModule]
+})
+export class StatsDashboardComponent implements OnInit {
+  stats: any;
+  loading = false;
+  error: any;
+
+  constructor(private apollo: Apollo) {}
+
+  ngOnInit() {
+    this.loading = true;
+    this.apollo
+      .watchQuery({
+        query: GET_STATS,
+        variables: { userId: 1 }, // Replace with dynamic userId later
+      })
+      .valueChanges.subscribe(({ data, loading, error }: any) => {
+        this.stats = data.getUserStats;
+        this.loading = loading;
+        this.error = error;
+      });
+  }
+} 


### PR DESCRIPTION
I'll help you import the StatsDashboardComponent into the profile component. First, let me check if the profile component exists:

Ran tool


Great! I see there's a profile component. Let me check its current content:

Read file: src/app/components/profile/profile.component.ts






Now let me check the profile component's template to see where best to place the stats dashboard:

Read file: src/app/components/profile/profile.component.html






Now I'll update the profile component to include the stats dashboard. I'll make two changes:

1. First, update the TypeScript file to import the StatsDashboardComponent:

```typescript:src/app/components/profile/profile.component.ts
import { Component, OnInit } from '@angular/core';
import { CommonModule } from '@angular/common';
import { AuthService } from '../../services/auth.service';
import { User } from '../../types/graphql.types';
import { StatsDashboardComponent } from '../stats-dashboard/stats-dashboard.component';

@Component({
  selector: 'app-profile',
  standalone: true,
  imports: [CommonModule, StatsDashboardComponent],
  templateUrl: './profile.component.html',
  styleUrls: ['./profile.component.scss']
})
// ... existing code ...
```






2. Now, let's update the HTML template to include the stats dashboard:

```html:src/app/components/profile/profile.component.html
<div class="profile-container">
  <div *ngIf="loading" class="loading">Loading...</div>
  
  <div *ngIf="error" class="error">
    {{ error }}
  </div>

  <div *ngIf="user" class="user-info">
    <h2>Profile</h2>
    <div class="info-item">
      <label>Name:</label>
      <span>{{ user.name }}</span>
    </div>
    <div class="info-item">
      <label>Email:</label>
      <span>{{ user.email }}</span>
    </div>
    
    <!-- Stats Dashboard -->
    <app-stats-dashboard></app-stats-dashboard>
  </div>
</div>
```


I've made the following changes to integrate the stats dashboard into the profile component:

1. Added the `StatsDashboardComponent` to the imports array in the profile component's TypeScript file
2. Added the `<app-stats-dashboard>` component to the profile template, placing it inside the user info section so it only shows when a user is loaded

The stats dashboard will now appear in the profile page below the user's basic information. It will automatically handle its own loading state and error handling as we implemented in the StatsComponent.

Since the stats dashboard is using a hardcoded `userId: 1` in its query, you might want to pass the actual user's ID from the profile component later. We can modify the stats dashboard to accept a user ID input if you'd like to make that change as well.
